### PR TITLE
Flow metrics: provide lazy-initiazed implementation

### DIFF
--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -540,6 +540,7 @@ Each flow stat includes rates for one or more recent windows of time:
 
 // Templates for short-hand notes in the table below
 :flow-stable: pass:quotes[*Stable*]
+:flow-preview: pass:quotes[_Technology Preview_]
 
 [%autowidth.stretch]
 |===
@@ -547,8 +548,16 @@ Each flow stat includes rates for one or more recent windows of time:
 
 | `current`         | {flow-stable}  | the most recent ~10s
 | `lifetime`        | {flow-stable}  | the lifetime of the relevant pipeline or process
+| `last_1_minute`   | {flow-preview} | the most recent ~1 minute
+| `last_5_minutes`  | {flow-preview} | the most recent ~5 minutes
+| `last_15_minutes` | {flow-preview} | the most recent ~15 minutes
+| `last_1_hour`     | {flow-preview} | the most recent ~1 hour
+| `last_24_hours`   | {flow-preview} | the most recent ~24 hours
 
 |===
+
+NOTE: The flow rate windows marked as "Technology Preview" are subject to change without notice.
+      Future releases of {ls} may include more, fewer, or different windows for each rate in response to community feedback.
 
 [discrete]
 [[pipeline-stats]]

--- a/docs/static/monitoring/monitoring-apis.asciidoc
+++ b/docs/static/monitoring/monitoring-apis.asciidoc
@@ -536,6 +536,20 @@ Additionally, some amount of back-pressure is both _normal_ and _expected_ for p
 
 |===
 
+Each flow stat includes rates for one or more recent windows of time:
+
+// Templates for short-hand notes in the table below
+:flow-stable: pass:quotes[*Stable*]
+
+[%autowidth.stretch]
+|===
+| Flow Window       | Availability   | Definition
+
+| `current`         | {flow-stable}  | the most recent ~10s
+| `lifetime`        | {flow-stable}  | the lifetime of the relevant pipeline or process
+
+|===
+
 [discrete]
 [[pipeline-stats]]
 ==== Pipeline stats

--- a/logstash-core/lib/logstash/agent.rb
+++ b/logstash-core/lib/logstash/agent.rb
@@ -571,7 +571,7 @@ class LogStash::Agent
   private :get_counter
 
   def create_flow_metric(name, numerator_metric, denominator_metric)
-    org.logstash.instrument.metrics.FlowMetric.new(name, numerator_metric, denominator_metric)
+    org.logstash.instrument.metrics.FlowMetric.create(name, numerator_metric, denominator_metric)
   end
   private :create_flow_metric
 

--- a/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
+++ b/logstash-core/src/main/java/org/logstash/execution/AbstractPipelineExt.java
@@ -75,11 +75,11 @@ import org.logstash.ext.JRubyAbstractQueueWriteClientExt;
 import org.logstash.ext.JRubyWrappedWriteClientExt;
 import org.logstash.instrument.metrics.AbstractMetricExt;
 import org.logstash.instrument.metrics.AbstractNamespacedMetricExt;
-import org.logstash.instrument.metrics.FlowMetric;
 import org.logstash.instrument.metrics.Metric;
 import org.logstash.instrument.metrics.NullMetricExt;
 import org.logstash.instrument.metrics.UptimeMetric;
 import org.logstash.instrument.metrics.counter.LongCounter;
+import org.logstash.instrument.metrics.FlowMetric;
 import org.logstash.plugins.ConfigVariableExpander;
 import org.logstash.plugins.factory.ExecutionContextFactoryExt;
 import org.logstash.plugins.factory.PluginFactoryExt;
@@ -527,7 +527,7 @@ public class AbstractPipelineExt extends RubyBasicObject {
     private static FlowMetric createFlowMetric(final RubySymbol name,
                                                final Metric<? extends Number> numeratorMetric,
                                                final Metric<? extends Number> denominatorMetric) {
-        return new FlowMetric(name.asJavaString(), numeratorMetric, denominatorMetric);
+        return FlowMetric.create(name.asJavaString(), numeratorMetric, denominatorMetric);
     }
 
     private LongCounter initOrGetCounterMetric(final ThreadContext context,

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/BaseFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/BaseFlowMetric.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.instrument.metrics;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * This {@link BaseFlowMetric} is a shared-common base for all internal implementations of {@link FlowMetric}.
+ */
+abstract class BaseFlowMetric extends AbstractMetric<Map<String,Double>> implements FlowMetric {
+
+    static final Logger LOGGER = LogManager.getLogger(BaseFlowMetric.class);
+
+    // metric sources
+    private final Metric<? extends Number> numeratorMetric;
+    private final Metric<? extends Number> denominatorMetric;
+
+    protected final FlowCapture lifetimeBaseline;
+
+    final LongSupplier nanoTimeSupplier;
+
+    BaseFlowMetric(final LongSupplier nanoTimeSupplier,
+                   final String name,
+                   final Metric<? extends Number> numeratorMetric,
+                   final Metric<? extends Number> denominatorMetric) {
+        super(name);
+        this.nanoTimeSupplier = nanoTimeSupplier;
+        this.numeratorMetric = numeratorMetric;
+        this.denominatorMetric = denominatorMetric;
+
+        this.lifetimeBaseline = doCapture();
+        LOGGER.trace("FlowMetric({}) -> {}", name, lifetimeBaseline);
+    }
+
+    @Override
+    public MetricType getType() {
+        return MetricType.FLOW_RATE;
+    }
+
+    protected FlowCapture doCapture() {
+        return new FlowCapture(nanoTimeSupplier.getAsLong(), numeratorMetric.getValue(), denominatorMetric.getValue());
+    }
+
+    /**
+     * @param current the most-recent {@link FlowCapture}
+     * @param baseline a non-null {@link FlowCapture} from which to compare.
+     * @return an {@link OptionalDouble} that will be non-empty IFF we have sufficient information
+     * to calculate a finite rate of change of the numerator relative to the denominator.
+     */
+    protected static OptionalDouble calculateRate(final FlowCapture current, final FlowCapture baseline) {
+        Objects.requireNonNull(baseline, "baseline");
+        if (baseline == current) { return OptionalDouble.empty(); }
+
+        final BigDecimal deltaNumerator = current.numerator().subtract(baseline.numerator());
+        final BigDecimal deltaDenominator = current.denominator().subtract(baseline.denominator());
+
+        if (deltaDenominator.signum() == 0) {
+            return OptionalDouble.empty();
+        }
+
+        final BigDecimal rate = deltaNumerator.divide(deltaDenominator, 3, RoundingMode.HALF_UP);
+
+        return OptionalDouble.of(rate.doubleValue());
+    }
+
+    /**
+     * @param current the most-recent {@link FlowCapture}
+     * @param possibleBaseline a {@link Supplier}{@code <FlowCapture>} that may return null
+     * @return an {@link OptionalDouble} that will be non-empty IFF we have sufficient information
+     * to calculate a finite rate of change of the numerator relative to the denominator.
+     */
+    protected static OptionalDouble calculateRate(final FlowCapture current, final Supplier<FlowCapture> possibleBaseline) {
+        return Optional.ofNullable(possibleBaseline.get())
+                .map((baseline) -> calculateRate(current, baseline))
+                .orElseGet(OptionalDouble::empty);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/BaseFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/BaseFlowMetric.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.Map;
 import java.util.Objects;
@@ -45,6 +46,8 @@ abstract class BaseFlowMetric extends AbstractMetric<Map<String,Double>> impleme
     protected final FlowCapture lifetimeBaseline;
 
     final LongSupplier nanoTimeSupplier;
+
+    static final MathContext LIMITED_PRECISION = new MathContext(4, RoundingMode.HALF_UP);
 
     BaseFlowMetric(final LongSupplier nanoTimeSupplier,
                    final String name,
@@ -85,7 +88,7 @@ abstract class BaseFlowMetric extends AbstractMetric<Map<String,Double>> impleme
             return OptionalDouble.empty();
         }
 
-        final BigDecimal rate = deltaNumerator.divide(deltaDenominator, 3, RoundingMode.HALF_UP);
+        final BigDecimal rate = deltaNumerator.divide(deltaDenominator, LIMITED_PRECISION);
 
         return OptionalDouble.of(rate.doubleValue());
     }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/BaseFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/BaseFlowMetric.java
@@ -104,4 +104,5 @@ abstract class BaseFlowMetric extends AbstractMetric<Map<String,Double>> impleme
                 .map((baseline) -> calculateRate(current, baseline))
                 .orElseGet(OptionalDouble::empty);
     }
+
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/ExtendedFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/ExtendedFlowMetric.java
@@ -1,0 +1,324 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.instrument.metrics;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalDouble;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
+
+import static org.logstash.instrument.metrics.FlowMetricRetentionPolicy.BuiltInRetentionPolicy;
+
+/**
+ * The {@link ExtendedFlowMetric} is an implementation of {@link FlowMetric} that produces
+ * a variable number of rates defined by {@link FlowMetricRetentionPolicy}-s, retaining no
+ * more {@link FlowCapture}s than necessary to satisfy the requested resolution or the
+ * requested retention. This implementation is lock-free and concurrency-safe.
+ */
+public class ExtendedFlowMetric extends BaseFlowMetric {
+    static final Logger LOGGER = LogManager.getLogger(ExtendedFlowMetric.class);
+    static final String LIFETIME_KEY = "lifetime";
+
+    private final List<RetentionWindow> retentionWindows;
+
+    public ExtendedFlowMetric(final String name,
+                              final Metric<? extends Number> numeratorMetric,
+                              final Metric<? extends Number> denominatorMetric) {
+        this(System::nanoTime, name, numeratorMetric, denominatorMetric);
+    }
+
+    ExtendedFlowMetric(final LongSupplier nanoTimeSupplier,
+                       final String name,
+                       final Metric<? extends Number> numeratorMetric,
+                       final Metric<? extends Number> denominatorMetric,
+                       final Collection<? extends FlowMetricRetentionPolicy> retentionPolicies) {
+        super(nanoTimeSupplier, name, numeratorMetric, denominatorMetric);
+
+        retentionWindows = retentionPolicies.stream()
+                                            .map(this::retentionWindowFromRetentionPolicy)
+                                            .collect(Collectors.toUnmodifiableList());
+    }
+
+    public ExtendedFlowMetric(final LongSupplier nanoTimeSupplier,
+                              final String name,
+                              final Metric<? extends Number> numeratorMetric,
+                              final Metric<? extends Number> denominatorMetric) {
+        this(nanoTimeSupplier, name, numeratorMetric, denominatorMetric, EnumSet.allOf(BuiltInRetentionPolicy.class));
+    }
+
+    @Override
+    public void capture() {
+        final FlowCapture candidateCapture = doCapture();
+        this.retentionWindows.forEach(window -> window.append(candidateCapture));
+    }
+
+    @Override
+    public Map<String, Double> getValue() {
+        final FlowCapture currentCapture = doCapture();
+
+        final Map<String, Double> rates = new LinkedHashMap<>();
+
+        this.retentionWindows.forEach(window -> window.baseline(currentCapture.nanoTime())
+                             .map((b) -> calculateRate(currentCapture, b))
+                             .orElseGet(OptionalDouble::empty)
+                             .ifPresent((rate) -> rates.put(window.policy.policyName(), rate)));
+
+        calculateRate(currentCapture, lifetimeBaseline).ifPresent((rate) -> rates.put(LIFETIME_KEY, rate));
+
+        return Collections.unmodifiableMap(rates);
+    }
+
+    /**
+     * Internal tooling to select the younger of two captures
+     */
+    private static FlowCapture selectNewerCapture(final FlowCapture existing, final FlowCapture proposed) {
+        if (existing == null) { return proposed; }
+        if (proposed == null) { return existing; }
+
+        return (existing.nanoTime() > proposed.nanoTime()) ? existing : proposed;
+    }
+
+    /**
+     * Internal introspection for tests to measure how many captures we are retaining.
+     * @return the number of captures in all tracked windows
+     */
+    int estimateCapturesRetained() {
+        return this.retentionWindows.stream()
+                                    .map(RetentionWindow::estimateSize)
+                                    .mapToInt(Integer::intValue)
+                                    .sum();
+    }
+
+    /**
+     * Internal introspection for tests to measure excess retention.
+     * @param retentionWindowFunction given a policy, return a retention window, in nanos
+     * @return the sum of over-retention durations.
+     */
+    Duration estimateExcessRetained(final ToLongFunction<FlowMetricRetentionPolicy> retentionWindowFunction) {
+        final long currentNanoTime = nanoTimeSupplier.getAsLong();
+        final long cumulativeExcessRetained = this.retentionWindows.stream()
+                .map(s -> s.excessRetained(currentNanoTime, retentionWindowFunction))
+                .mapToLong(Long::longValue)
+                .sum();
+        return Duration.ofNanos(cumulativeExcessRetained);
+    }
+
+    private RetentionWindow retentionWindowFromRetentionPolicy(final FlowMetricRetentionPolicy retentionPolicy) {
+        final RetentionWindow retentionWindow = new RetentionWindow(retentionPolicy, this.lifetimeBaseline);
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("{} created {}", this.name, retentionWindow);
+        }
+        return retentionWindow;
+    }
+
+    /**
+     * A {@link RetentionWindow} efficiently holds sufficient {@link FlowCapture}s to
+     * meet its {@link FlowMetricRetentionPolicy}, providing access to the youngest capture
+     * that is older than the policy's allowed retention (if any).
+     * The implementation is similar to a singly-linked list whose youngest captures are at
+     * the tail and oldest captures are at the head, with an additional pre-tail stag.
+     * Compaction is always done at read-time and occasionally at write-time.
+     * Both reads and writes are concurrency-safe.
+     */
+    private static class RetentionWindow {
+        private final AtomicReference<FlowCapture> stagedCapture = new AtomicReference<>();
+        private final AtomicReference<Node> tail;
+        private final AtomicReference<Node> head;
+        private final FlowMetricRetentionPolicy policy;
+
+        RetentionWindow(final FlowMetricRetentionPolicy policy, final FlowCapture zeroCapture) {
+            this.policy = policy;
+            final Node zeroNode = new Node(zeroCapture);
+            this.head = new AtomicReference<>(zeroNode);
+            this.tail = new AtomicReference<>(zeroNode);
+        }
+
+        /**
+         * Append the newest {@link FlowCapture} into this {@link RetentionWindow},
+         * while respecting our {@link FlowMetricRetentionPolicy}.
+         * We tolerate minor jitter in the provided {@link FlowCapture#nanoTime()}, but
+         * expect callers of this method to minimize lag between instantiating the capture
+         * and appending it.
+         *
+         * @param newestCapture the newest capture to stage
+         */
+        private void append(final FlowCapture newestCapture) {
+            final Node casTail = this.tail.get(); // for CAS
+            final long newestCaptureNanoTime = newestCapture.nanoTime();
+
+            // stage our newest capture unless it is older than the currently-staged capture
+            final FlowCapture previouslyStaged = stagedCapture.getAndAccumulate(newestCapture, ExtendedFlowMetric::selectNewerCapture);
+
+            // promote our previously-staged capture IFF our newest capture is too far
+            // ahead of the current tail to support policy's resolution.
+            if (previouslyStaged != null && Math.subtractExact(newestCaptureNanoTime, casTail.captureNanoTime()) > policy.resolutionNanos()) {
+                // attempt to set an _unlinked_ Node to our tail
+                final Node proposedNode = new Node(previouslyStaged);
+                if (this.tail.compareAndSet(casTail, proposedNode)) {
+                    // if we succeeded at setting an unlinked node, link to it from our old tail
+                    casTail.setNext(proposedNode);
+
+                    // perform a force-compaction of our head if necessary,
+                    // detected using plain memory access
+                    final Node currentHead = head.getPlain();
+                    final long headAgeNanos = Math.subtractExact(newestCaptureNanoTime, currentHead.captureNanoTime());
+                    if (LOGGER.isTraceEnabled()) {
+                        LOGGER.trace("{} post-append result (captures: `{}` span: `{}` }", this, estimateSize(currentHead), Duration.ofNanos(headAgeNanos));
+                    }
+                    if (headAgeNanos > policy.forceCompactionNanos()) {
+                        final Node compactHead = compactHead(Math.subtractExact(newestCaptureNanoTime, policy.retentionNanos()));
+                        if (LOGGER.isDebugEnabled()) {
+                            final long compactHeadAgeNanos = Math.subtractExact(newestCaptureNanoTime, compactHead.captureNanoTime());
+                            LOGGER.debug("{} forced-compaction result (captures: `{}` span: `{}`)", this, estimateSize(compactHead), Duration.ofNanos(compactHeadAgeNanos));
+                        }
+                    }
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "RetentionWindow{" +
+                    "policy=" + policy.policyName() +
+                    " id=" + System.identityHashCode(this) +
+                    '}';
+        }
+
+        /**
+         * @param nanoTime the nanoTime of the capture for which we are retrieving a baseline.
+         * @return an {@link Optional} that contains the youngest {@link FlowCapture} that is older
+         *         than this window's {@link FlowMetricRetentionPolicy} allowed retention if one
+         *         exists, and is otherwise empty.
+         */
+        public Optional<FlowCapture> baseline(final long nanoTime) {
+            final long barrier = Math.subtractExact(nanoTime, policy.retentionNanos());
+            final Node head = compactHead(barrier);
+            if (head.captureNanoTime() <= barrier) {
+                return Optional.of(head.capture);
+            } else {
+                return Optional.empty();
+            }
+        }
+
+        /**
+         * @return a computationally-expensive estimate of the number of captures in this window,
+         *         using plain memory access. This should NOT be run in unguarded production code.
+         */
+        private static int estimateSize(final Node headNode) {
+            int i = 1; // assume we have one additional staged
+            // NOTE: we chase the provided headNode's tail with plain-gets,
+            //       which tolerates missed appends from other threads.
+            for (Node current = headNode; current != null; current = current.getNextPlain()) { i++; }
+            return i;
+        }
+
+        /**
+         * @see RetentionWindow#estimateSize(Node)
+         */
+        private int estimateSize() {
+            return estimateSize(this.head.getPlain());
+        }
+
+        /**
+         * @param barrier a nanotime that will NOT be crossed during compaction
+         * @return the head node after compaction up to the provided barrier.
+         */
+        private Node compactHead(final long barrier) {
+            return this.head.updateAndGet((existingHead) -> {
+                final Node proposedHead = existingHead.seekWithoutCrossing(barrier);
+                return Objects.requireNonNullElse(proposedHead, existingHead);
+            });
+        }
+
+        /**
+         * Internal testing support
+         */
+        private long excessRetained(final long currentNanoTime, final ToLongFunction<FlowMetricRetentionPolicy> retentionWindowFunction) {
+            final long barrier = Math.subtractExact(currentNanoTime, retentionWindowFunction.applyAsLong(this.policy));
+            return Math.max(0L, Math.subtractExact(barrier, this.head.getPlain().captureNanoTime()));
+        }
+
+        /**
+         * A {@link Node} holds a single {@link FlowCapture} and
+         * may link ahead to the next {@link Node}.
+         * It is an implementation detail of {@link RetentionWindow}.
+         */
+        private static class Node {
+            private static final VarHandle NEXT;
+            static {
+                try {
+                    MethodHandles.Lookup l = MethodHandles.lookup();
+                    NEXT = l.findVarHandle(Node.class, "next", Node.class);
+                } catch (ReflectiveOperationException e) {
+                    throw new ExceptionInInitializerError(e);
+                }
+            }
+
+            private final FlowCapture capture;
+            private volatile Node next;
+
+            Node(final FlowCapture capture) {
+                this.capture = capture;
+            }
+
+            Node seekWithoutCrossing(final long barrier) {
+                Node newestOlderThanThreshold = null;
+                Node candidate = this;
+
+                while(candidate != null && candidate.captureNanoTime() < barrier) {
+                    newestOlderThanThreshold = candidate;
+                    candidate = candidate.getNext();
+                }
+                return newestOlderThanThreshold;
+            }
+
+            long captureNanoTime() {
+                return this.capture.nanoTime();
+            }
+
+            void setNext(final Node nextNode) {
+                next = nextNode;
+            }
+
+            Node getNext() {
+                return next;
+            }
+
+            Node getNextPlain() {
+                return (Node)NEXT.get(this);
+            }
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowCapture.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowCapture.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.instrument.metrics;
+
+import java.math.BigDecimal;
+
+/**
+ * A {@link FlowCapture} is used by {@link FlowMetric} to hold
+ * point-in-time data for a pair of {@link Metric}s.
+ * It is immutable.
+ */
+class FlowCapture {
+    private final Number numerator;
+    private final Number denominator;
+
+    private final long nanoTime;
+
+    public FlowCapture(final long nanoTime,
+                       final Number numerator,
+                       final Number denominator) {
+        this.numerator = numerator;
+        this.denominator = denominator;
+        this.nanoTime = nanoTime;
+    }
+
+    /**
+     * @return the nanoTime of this capture, as provided at time
+     *         of capture by the {@link FlowMetric}.
+     */
+    public long nanoTime() {
+        return nanoTime;
+    }
+
+    /**
+     * @return the value of the numerator metric at time of capture.
+     */
+    public BigDecimal numerator() {
+        return BigDecimal.valueOf(numerator.doubleValue());
+    }
+
+    /**
+     * @return the value of the denominator metric at time of capture.
+     */
+    public BigDecimal denominator() {
+        return BigDecimal.valueOf(denominator.doubleValue());
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() +"{" +
+                "nanoTimestamp=" + nanoTime +
+                " numerator=" + numerator() +
+                " denominator=" + denominator() +
+                '}';
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -19,139 +19,20 @@
 
 package org.logstash.instrument.metrics;
 
-import java.math.BigDecimal;
-import java.math.RoundingMode;
-import java.time.Duration;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.OptionalDouble;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.LongSupplier;
-import java.util.function.Supplier;
 
-public class FlowMetric extends AbstractMetric<Map<String,Double>> {
+/**
+ * A {@link FlowMetric} reports the rates of change of one metric (the numerator)
+ * relative to another (the denominator), over one or more windows.
+ * The instantiator of a {@link FlowMetric} is responsible for ensuring it is
+ * sent {@link FlowMetric#capture} on a regular cadence.
+ */
+public interface FlowMetric extends Metric<Map<String,Double>> {
+    void capture();
 
-    // metric sources
-    private final Metric<? extends Number> numeratorMetric;
-    private final Metric<? extends Number> denominatorMetric;
-
-    // useful capture nodes for calculation
-    private final Capture baseline;
-
-    private final AtomicReference<Capture> head;
-    private final AtomicReference<Capture> instant = new AtomicReference<>();
-
-    private final LongSupplier nanoTimeSupplier;
-
-    static final String LIFETIME_KEY = "lifetime";
-    static final String CURRENT_KEY = "current";
-
-    public FlowMetric(final String name,
-                      final Metric<? extends Number> numeratorMetric,
-                      final Metric<? extends Number> denominatorMetric) {
-        this(System::nanoTime, name, numeratorMetric, denominatorMetric);
-    }
-
-    FlowMetric(final LongSupplier nanoTimeSupplier,
-               final String name,
-               final Metric<? extends Number> numeratorMetric,
-               final Metric<? extends Number> denominatorMetric) {
-        super(name);
-        this.nanoTimeSupplier = nanoTimeSupplier;
-        this.numeratorMetric = numeratorMetric;
-        this.denominatorMetric = denominatorMetric;
-
-        this.baseline = doCapture();
-        this.head = new AtomicReference<>(this.baseline);
-    }
-
-    public void capture() {
-        final Capture newestHead = doCapture();
-        final Capture previousHead = head.getAndSet(newestHead);
-        instant.getAndAccumulate(previousHead, (current, given) -> {
-            // keep our current value if the given one is less than ~100ms older than our newestHead
-            // this is naive and when captures happen too frequently without relief can result in
-            // our "current" window growing indefinitely, but we are shipping with a 5s cadence
-            // and shouldn't hit this edge-case in practice.
-            return (newestHead.calculateCapturePeriod(given).toMillis() > 100) ? given : current;
-        });
-    }
-
-    /**
-     * @return a map containing all available finite rates (see {@link Capture#calculateRate(Capture)})
-     */
-    public Map<String, Double> getValue() {
-        final Capture headCapture = head.get();
-        if (Objects.isNull(headCapture)) {
-            return Map.of();
-        }
-
-        final Map<String, Double> rates = new HashMap<>();
-
-        headCapture.calculateRate(baseline).ifPresent((rate) -> rates.put(LIFETIME_KEY, rate));
-        headCapture.calculateRate(instant::get).ifPresent((rate) -> rates.put(CURRENT_KEY,  rate));
-
-        return Map.copyOf(rates);
-    }
-
-    Capture doCapture() {
-        return new Capture(numeratorMetric.getValue(), denominatorMetric.getValue(), nanoTimeSupplier.getAsLong());
-    }
-
-    @Override
-    public MetricType getType() {
-        return MetricType.FLOW_RATE;
-    }
-
-    private static class Capture {
-        private final Number numerator;
-        private final Number denominator;
-
-        private final long nanoTimestamp;
-
-        public Capture(final Number numerator, final Number denominator, final long nanoTimestamp) {
-            this.numerator = numerator;
-            this.denominator = denominator;
-            this.nanoTimestamp = nanoTimestamp;
-        }
-
-        /**
-         *
-         * @param baseline a non-null {@link Capture} from which to compare.
-         * @return an {@link OptionalDouble} that will be non-empty IFF we have sufficient information
-         *         to calculate a finite rate of change of the numerator relative to the denominator.
-         */
-        OptionalDouble calculateRate(final Capture baseline) {
-            Objects.requireNonNull(baseline, "baseline");
-            if (baseline == this) { return OptionalDouble.empty(); }
-
-            final double deltaNumerator = this.numerator.doubleValue() - baseline.numerator.doubleValue();
-            final double deltaDenominator = this.denominator.doubleValue() - baseline.denominator.doubleValue();
-
-            // divide-by-zero safeguard
-            if (deltaDenominator == 0.0) { return OptionalDouble.empty(); }
-
-            // To prevent the appearance of false-precision, we round to 3 decimal places.
-            return OptionalDouble.of(BigDecimal.valueOf(deltaNumerator)
-                                               .divide(BigDecimal.valueOf(deltaDenominator), 3, RoundingMode.HALF_UP)
-                                               .doubleValue());
-        }
-
-        /**
-         * @param possibleBaseline a {@link Supplier<Capture>} that may return null
-         * @return an {@link OptionalDouble} that will be non-empty IFF we have sufficient information
-         *         to calculate a finite rate of change of the numerator relative to the denominator.
-         */
-        OptionalDouble calculateRate(final Supplier<Capture> possibleBaseline) {
-            return Optional.ofNullable(possibleBaseline.get())
-                           .map(this::calculateRate)
-                           .orElseGet(OptionalDouble::empty);
-        }
-
-        Duration calculateCapturePeriod(final Capture baseline) {
-            return Duration.ofNanos(Math.subtractExact(this.nanoTimestamp, baseline.nanoTimestamp));
-        }
+    static FlowMetric create(final String name,
+                             final Metric<? extends Number> numerator,
+                             final Metric<? extends Number> denominator) {
+        return new SimpleFlowMetric(name, numerator, denominator);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -33,6 +33,10 @@ public interface FlowMetric extends Metric<Map<String,Double>> {
     static FlowMetric create(final String name,
                              final Metric<? extends Number> numerator,
                              final Metric<? extends Number> denominator) {
-        return new SimpleFlowMetric(name, numerator, denominator);
+        switch (System.getProperty("logstash.flowMetric", "extended")) {
+            case "extended": return new ExtendedFlowMetric(name, numerator, denominator);
+            case "simple"  :
+            default        : return new SimpleFlowMetric(name, numerator, denominator);
+        }
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetric.java
@@ -20,6 +20,7 @@
 package org.logstash.instrument.metrics;
 
 import java.util.Map;
+import java.util.function.Supplier;
 
 /**
  * A {@link FlowMetric} reports the rates of change of one metric (the numerator)
@@ -38,5 +39,11 @@ public interface FlowMetric extends Metric<Map<String,Double>> {
             case "simple"  :
             default        : return new SimpleFlowMetric(name, numerator, denominator);
         }
+    }
+
+    static <N extends Number, D extends Number> FlowMetric create(final String name,
+                                                                  final Supplier<Metric<N>> numeratorSupplier,
+                                                                  final Supplier<Metric<D>> denominatorSupplier) {
+        return new LazyInstantiatedFlowMetric<>(name, numeratorSupplier, denominatorSupplier);
     }
 }

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetricRetentionPolicy.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/FlowMetricRetentionPolicy.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.logstash.instrument.metrics;
+
+import java.time.Duration;
+
+interface FlowMetricRetentionPolicy {
+    String policyName();
+
+    long resolutionNanos();
+
+    long retentionNanos();
+
+    long forceCompactionNanos();
+
+    enum BuiltInRetentionPolicy implements FlowMetricRetentionPolicy {
+                              // MAX_RETENTION,  MIN_RESOLUTION           @1sec  @5sec
+                CURRENT(Duration.ofSeconds(10), Duration.ofSeconds(1)), //10ish  3ish
+          LAST_1_MINUTE(Duration.ofMinutes(1),  Duration.ofSeconds(3)), //20ish  12ish
+         LAST_5_MINUTES(Duration.ofMinutes(5),  Duration.ofSeconds(15)),//20ish  -> 31ish ~10s
+        LAST_15_MINUTES(Duration.ofMinutes(15), Duration.ofSeconds(30)),//30ish  -> 37ish ~25s
+            LAST_1_HOUR(Duration.ofHours(1),    Duration.ofMinutes(1)), //60ish
+          LAST_24_HOURS(Duration.ofHours(24),   Duration.ofMinutes(15)),//100ish
+        ;
+
+        final long resolutionNanos;
+        final long retentionNanos;
+
+        final long forceCompactionNanos;
+
+        final transient String nameLower;
+
+        BuiltInRetentionPolicy(final Duration maximumRetention, final Duration minimumResolution) {
+            this.retentionNanos = maximumRetention.toNanos();
+            this.resolutionNanos = minimumResolution.toNanos();
+
+            // we generally rely on query-time compaction, and only perform insertion-time compaction
+            // if our series' head entry is significantly older than our maximum retention, which
+            // allows us to ensure a reasonable upper-bound of collection size without incurring the
+            // cost of compaction too often or inspecting the collection's size.
+            final long forceCompactionMargin = Math.max(Duration.ofSeconds(30).toNanos(),
+                                                        Math.multiplyExact(resolutionNanos, 8));
+            this.forceCompactionNanos = Math.addExact(retentionNanos, forceCompactionMargin);
+
+            this.nameLower = name().toLowerCase();
+        }
+
+        @Override
+        public long resolutionNanos() {
+            return this.resolutionNanos;
+        }
+
+        @Override
+        public long retentionNanos() {
+            return this.retentionNanos;
+        }
+
+        @Override
+        public long forceCompactionNanos() {
+            return this.forceCompactionNanos;
+        }
+
+        @Override
+        public String policyName() {
+            return nameLower;
+        }
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/LazyInstantiatedFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/LazyInstantiatedFlowMetric.java
@@ -1,0 +1,77 @@
+package org.logstash.instrument.metrics;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+
+public class LazyInstantiatedFlowMetric<N extends Number, D extends Number> implements FlowMetric {
+
+    static final Logger LOGGER = LogManager.getLogger(LazyInstantiatedFlowMetric.class);
+
+    private final String name;
+
+    private final Supplier<Metric<N>> numeratorSupplier;
+    private final Supplier<Metric<D>> denominatorSupplier;
+
+    private final AtomicReference<FlowMetric> inner = new AtomicReference<>();
+
+    private static final Map<String,Double> EMPTY_MAP = Map.of();
+
+    public LazyInstantiatedFlowMetric(final String name,
+                                      final Supplier<Metric<N>> numeratorSupplier,
+                                      final Supplier<Metric<D>> denominatorSupplier) {
+        this.name = name;
+        this.numeratorSupplier = numeratorSupplier;
+        this.denominatorSupplier = denominatorSupplier;
+    }
+
+    @Override
+    public void capture() {
+        final Optional<FlowMetric> inner = getInner();
+        if (inner.isPresent()) {
+            inner.get().capture();
+        } else {
+            LOGGER.warn("Underlying metrics for `{}` not yet instantiated, could not capture their rates", this.name);
+        }
+    }
+
+    @Override
+    public String getName() {
+        return this.name;
+    }
+
+    @Override
+    public MetricType getType() {
+        return MetricType.FLOW_RATE;
+    }
+
+    @Override
+    public Map<String, Double> getValue() {
+        return getInner().map(FlowMetric::getValue).orElse(EMPTY_MAP);
+    }
+
+    private Optional<FlowMetric> getInner() {
+        return Optional.ofNullable(inner.getPlain()) // avoid volatile reads
+                       .or(this::attemptCreateInner);
+    }
+
+    private Optional<FlowMetric> attemptCreateInner() {
+        final FlowMetric effectiveInner = inner.updateAndGet((existing) -> {
+            if (Objects.nonNull(existing)) { return existing; }
+
+            final Metric<N> numeratorMetric = numeratorSupplier.get();
+            if (Objects.isNull(numeratorMetric)) { return null; }
+
+            final Metric<D> denominatorMetric = denominatorSupplier.get();
+            if (Objects.isNull(denominatorMetric)) { return null; }
+
+            return FlowMetric.create(this.name, numeratorMetric, denominatorMetric);
+        });
+        return Optional.ofNullable(effectiveInner);
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/SimpleFlowMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/SimpleFlowMetric.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+* under the License.
+ */
+
+package org.logstash.instrument.metrics;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+/**
+ * The {@link SimpleFlowMetric} is an implementation of {@link FlowMetric} that
+ * produces only `lifetime` and a naively-calculated `current` rate using the two
+ * most-recent {@link FlowCapture}s.
+ */
+class SimpleFlowMetric extends BaseFlowMetric {
+
+    // useful capture nodes for calculation
+
+    private final AtomicReference<FlowCapture> head;
+    private final AtomicReference<FlowCapture> instant = new AtomicReference<>();
+
+    static final String LIFETIME_KEY = "lifetime";
+    static final String CURRENT_KEY = "current";
+
+    public SimpleFlowMetric(final String name,
+                            final Metric<? extends Number> numeratorMetric,
+                            final Metric<? extends Number> denominatorMetric) {
+        this(System::nanoTime, name, numeratorMetric, denominatorMetric);
+    }
+
+    SimpleFlowMetric(final LongSupplier nanoTimeSupplier,
+                     final String name,
+                     final Metric<? extends Number> numeratorMetric,
+                     final Metric<? extends Number> denominatorMetric) {
+        super(nanoTimeSupplier, name, numeratorMetric, denominatorMetric);
+
+        this.head = new AtomicReference<>(this.lifetimeBaseline);
+    }
+
+    @Override
+    public void capture() {
+        final FlowCapture newestHead = doCapture();
+        final FlowCapture previousHead = head.getAndSet(newestHead);
+        instant.getAndAccumulate(previousHead, (current, given) -> {
+            // keep our current value if the given one is less than ~100ms older than our newestHead
+            // this is naive and when captures happen too frequently without relief can result in
+            // our "current" window growing indefinitely, but we are shipping with a 5s cadence
+            // and shouldn't hit this edge-case in practice.
+            return (calculateCapturePeriod(newestHead, given).toMillis() > 100) ? given : current;
+        });
+    }
+
+    /**
+     * @return a map containing all available finite rates (see {@link BaseFlowMetric#calculateRate(FlowCapture,FlowCapture)})
+     */
+    @Override
+    public Map<String, Double> getValue() {
+        final FlowCapture headCapture = head.get();
+        if (Objects.isNull(headCapture)) {
+            return Map.of();
+        }
+
+        final Map<String, Double> rates = new HashMap<>();
+
+        calculateRate(headCapture, lifetimeBaseline).ifPresent((rate) -> rates.put(LIFETIME_KEY, rate));
+        calculateRate(headCapture, instant::get).ifPresent((rate) -> rates.put(CURRENT_KEY,  rate));
+
+        return Map.copyOf(rates);
+    }
+
+    private static Duration calculateCapturePeriod(final FlowCapture current, final FlowCapture baseline) {
+        return Duration.ofNanos(Math.subtractExact(current.nanoTime(), baseline.nanoTime()));
+    }
+}

--- a/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
+++ b/logstash-core/src/main/java/org/logstash/instrument/metrics/UptimeMetric.java
@@ -63,7 +63,7 @@ public class UptimeMetric extends AbstractMetric<Long> {
         this(name, System::nanoTime);
     }
 
-    UptimeMetric(final String name, final LongSupplier nanoTimeSupplier) {
+    public UptimeMetric(final String name, final LongSupplier nanoTimeSupplier) {
         this(name, nanoTimeSupplier, nanoTimeSupplier.getAsLong(), TimeUnit.MILLISECONDS);
     }
 

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/ExtendedFlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/ExtendedFlowMetricTest.java
@@ -1,0 +1,56 @@
+package org.logstash.instrument.metrics;
+
+import org.junit.Test;
+import org.logstash.instrument.metrics.counter.LongCounter;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.*;
+
+public class ExtendedFlowMetricTest {
+    @Test
+    public void testBaselineFunctionality() {
+        final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
+        final LongCounter numeratorMetric = new LongCounter(MetricKeys.EVENTS_KEY.asJavaString());
+        final Metric<Number> denominatorMetric = new UptimeMetric("uptime", clock::nanoTime).withUnitsPrecise(UptimeMetric.ScaleUnits.SECONDS);
+
+        final ExtendedFlowMetric flowMetric = new ExtendedFlowMetric(clock::nanoTime, "flow", numeratorMetric, denominatorMetric);
+
+        // more than one day of 1s-granularity captures
+        // with increasing increments of our numerator metric.
+        for(int i=1; i<100_000; i++) {
+            clock.advance(Duration.ofSeconds(1));
+            numeratorMetric.increment(i);
+            flowMetric.capture();
+        }
+
+        // since we enforce compaction only on reads, ensure it doesn't grow unbounded with only writes
+        // or hold onto captures from before our force compaction threshold
+        assertThat(flowMetric.estimateCapturesRetained(), is(lessThan(320)));
+        assertThat(flowMetric.estimateExcessRetained(FlowMetricRetentionPolicy::forceCompactionNanos), is(equalTo(Duration.ZERO)));
+
+        // calculate the supplied rates
+        final Map<String, Double> flowMetricValue = flowMetric.getValue();
+        assertThat(flowMetricValue, hasEntry("current",         99990.0));
+        assertThat(flowMetricValue, hasEntry("last_1_minute",   99970.0));
+        assertThat(flowMetricValue, hasEntry("last_5_minutes",  99850.0));
+        assertThat(flowMetricValue, hasEntry("last_15_minutes", 99550.0));
+        assertThat(flowMetricValue, hasEntry("last_1_hour",     98180.0));
+        assertThat(flowMetricValue, hasEntry("last_24_hours",   56750.0));
+        assertThat(flowMetricValue, hasEntry("lifetime",        50000.0));
+
+        // ensure we are fully-compact.
+        assertThat(flowMetric.estimateCapturesRetained(), is(lessThan(250)));
+        assertThat(flowMetric.estimateExcessRetained(this::maxRetentionPlusMinResolutionBuffer), is(equalTo(Duration.ZERO)));
+    }
+
+    private long maxRetentionPlusMinResolutionBuffer(final FlowMetricRetentionPolicy policy) {
+        return Math.addExact(policy.retentionNanos(), policy.resolutionNanos());
+    }
+}

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/ManualAdvanceClock.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/ManualAdvanceClock.java
@@ -8,7 +8,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
-class ManualAdvanceClock extends Clock {
+public class ManualAdvanceClock extends Clock {
     private final ZoneId zoneId;
     private final AtomicReference<Instant> currentInstant;
     private final Instant zeroInstant;

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/SimpleFlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/SimpleFlowMetricTest.java
@@ -9,16 +9,16 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.*;
-import static org.logstash.instrument.metrics.FlowMetric.CURRENT_KEY;
-import static org.logstash.instrument.metrics.FlowMetric.LIFETIME_KEY;
+import static org.logstash.instrument.metrics.SimpleFlowMetric.LIFETIME_KEY;
+import static org.logstash.instrument.metrics.SimpleFlowMetric.CURRENT_KEY;
 
-public class FlowMetricTest {
+public class SimpleFlowMetricTest {
     @Test
     public void testBaselineFunctionality() {
         final ManualAdvanceClock clock = new ManualAdvanceClock(Instant.now());
         final LongCounter numeratorMetric = new LongCounter(MetricKeys.EVENTS_KEY.asJavaString());
         final Metric<Number> denominatorMetric = new UptimeMetric("uptime", clock::nanoTime).withUnitsPrecise(UptimeMetric.ScaleUnits.SECONDS);
-        final FlowMetric instance = new FlowMetric(clock::nanoTime, "flow", numeratorMetric, denominatorMetric);
+        final FlowMetric instance = new SimpleFlowMetric(clock::nanoTime, "flow", numeratorMetric, denominatorMetric);
 
         final Map<String, Double> ratesBeforeCaptures = instance.getValue();
         assertTrue(ratesBeforeCaptures.isEmpty());

--- a/logstash-core/src/test/java/org/logstash/instrument/metrics/SimpleFlowMetricTest.java
+++ b/logstash-core/src/test/java/org/logstash/instrument/metrics/SimpleFlowMetricTest.java
@@ -58,6 +58,6 @@ public class SimpleFlowMetricTest {
         instance.capture();
         final Map<String, Double> ratesAfterSmallAdvanceCapture = instance.getValue();
         assertFalse(ratesAfterNthCapture.isEmpty());
-        assertEquals(Map.of(LIFETIME_KEY, 367.408, CURRENT_KEY, 377.645), ratesAfterSmallAdvanceCapture);
+        assertEquals(Map.of(LIFETIME_KEY, 367.4, CURRENT_KEY, 377.6), ratesAfterSmallAdvanceCapture);
     }
 }


### PR DESCRIPTION
@mashhurs this is a `FlowMetric` imlementation that takes a pair of `Supplier<Metric>`s, and will instantiate and use an inner `FlowMetric` once both suppliers return a non-null value.