### PR TITLE
Suggestions to improve LS-to-LS spec.

### DIFF
--- a/qa/integration/services/logstash_service.rb
+++ b/qa/integration/services/logstash_service.rb
@@ -220,7 +220,7 @@ class LogstashService < Service
   # check REST API is responsive
   def rest_active?
     result = monitoring_api.node_info
-    started = !result.nil?
+    !result.nil?
   end
 
   def monitoring_api

--- a/qa/integration/specs/logstash_to_logstash_spec.rb
+++ b/qa/integration/specs/logstash_to_logstash_spec.rb
@@ -73,11 +73,6 @@ describe "Logstash to Logstash communication Integration test" do
         run_logstash_instance(output_config_name, all_config_options) do |upstream_logstash_service|
 
           try(num_retries) do
-            upstream_event_stats = upstream_logstash_service.monitoring_api.event_stats
-            expect(upstream_event_stats).to include({"out" => num_events}), lambda { "expected #{num_events} events to have been sent by upstream" }
-          end
-
-          try(num_retries) do
             downstream_event_stats = downstream_logstash_service.monitoring_api.event_stats
             expect(downstream_event_stats).to include({"in" => num_events}), lambda { "expected #{num_events} events to have been received by downstream" }
             expect(downstream_event_stats).to include({"out" => num_events}), lambda { "expected #{num_events} events to have been processed by downstream" }

--- a/qa/integration/specs/logstash_to_logstash_spec.rb
+++ b/qa/integration/specs/logstash_to_logstash_spec.rb
@@ -25,14 +25,7 @@ require 'logstash/devutils/rspec/spec_helper'
 
 describe "Logstash to Logstash communication Integration test" do
 
-  before(:all) {
-    @fixture = Fixture.new(__FILE__)
-    # backup original setting file since we change API port number, and restore after all tests
-    FileUtils.cp(@fixture.get_service('logstash').application_settings_file, "#{@fixture.get_service('logstash').application_settings_file}.original")
-  }
-
   after(:all) {
-    FileUtils.mv("#{@fixture.get_service('logstash').application_settings_file}.original", @fixture.get_service('logstash').application_settings_file)
     @fixture.teardown
   }
 
@@ -57,26 +50,10 @@ describe "Logstash to Logstash communication Integration test" do
                                     "--path.config", config_to_temp_file(@fixture.config(config_name, options)),
                                     "--path.data", get_temp_path_dir,
                                     "--api.http.port", api_port.to_s)
-    wait_for_logstash(logstash_service)
-
+    logstash_service.wait_for_rest_api
     yield logstash_service
-
   ensure
-    logstash_service&.teardown
-  end
-
-  def wait_for_logstash(service)
-    wait_in_seconds = 60
-    while wait_in_seconds > 0 do
-      begin
-        return if service.rest_active?
-      rescue => e
-        puts "Exception: #{e.message}"
-        wait_in_seconds -= 1
-        sleep 1
-      end
-    end
-    raise "Logstash is not responsive after 60 seconds."
+    logstash_service.teardown
   end
 
   let(:num_retries) { 60 }
@@ -96,8 +73,12 @@ describe "Logstash to Logstash communication Integration test" do
         run_logstash_instance(output_config_name, all_config_options) do |upstream_logstash_service|
 
           try(num_retries) do
-            downstream_event_stats = downstream_logstash_service.monitoring_api.event_stats
+            upstream_event_stats = upstream_logstash_service.monitoring_api.event_stats
+            expect(upstream_event_stats).to include({"out" => num_events}), lambda { "expected #{num_events} events to have been sent by upstream" }
+          end
 
+          try(num_retries) do
+            downstream_event_stats = downstream_logstash_service.monitoring_api.event_stats
             expect(downstream_event_stats).to include({"in" => num_events}), lambda { "expected #{num_events} events to have been received by downstream" }
             expect(downstream_event_stats).to include({"out" => num_events}), lambda { "expected #{num_events} events to have been processed by downstream" }
           end


### PR DESCRIPTION
### Description
Suggests two meaningful points:
- ~~Make sure upstream sends expected number of events before checking the expectation with downstream.~~ see the resolved discussions.
- We changed API port with `--api.http.port` param, which means persisting the config before run and removing after LS termination is not needed anymore, removing.
- In the past I moved/added methods (such as `wait_for_rest_api`) in `logstash_service.rb` used in widely. So, some part of logics in LS-to-LS spec duplicated, removing them.