### PR TITLE
Add heartbeat input to LS-to-LS integ test to keep LS alive.

### DIFF
--- a/qa/integration/fixtures/logstash_to_logstash_spec.yml
+++ b/qa/integration/fixtures/logstash_to_logstash_spec.yml
@@ -22,6 +22,15 @@ config:
       generator {
         count => '<%=options[:generator_count]%>'
       }
+      heartbeat {
+        interval => 1
+        message => "heartbeat"
+      }
+    }
+    filter {
+      if "heartbeat" == [message] {
+        drop {}
+      }
     }
     output {
       logstash {


### PR DESCRIPTION
Adds heartbeat-input to the LS to LS integration test config to keep upstream Logstash alive.